### PR TITLE
Fix eiger stream

### DIFF
--- a/src/tickit_devices/eiger/data/schema.py
+++ b/src/tickit_devices/eiger/data/schema.py
@@ -68,7 +68,7 @@ class ImageConfigHeader(BaseModel):
     Describes the metrics on the image acquisition.
     """
 
-    real_time: float
-    start_time: float
-    stop_time: float
+    real_time: int
+    start_time: int
+    stop_time: int
     htype: str = "dconfig-1.0"

--- a/src/tickit_devices/eiger/stream/eiger_stream.py
+++ b/src/tickit_devices/eiger/stream/eiger_stream.py
@@ -117,9 +117,9 @@ class EigerStream:
             type=image.dtype,
         )
         config_header = ImageConfigHeader(
-            real_time=0.0,
-            start_time=0.0,
-            stop_time=0.0,
+            real_time=0,
+            start_time=0,
+            stop_time=0,
         )
 
         self._buffer(header)

--- a/tests/eiger/test_eiger_stream.py
+++ b/tests/eiger/test_eiger_stream.py
@@ -140,8 +140,8 @@ def expected_image_blobs(image: Image) -> list[bytes | BaseModel]:
         ),
         image.data,
         ImageConfigHeader(
-            real_time=0.0,
-            start_time=0.0,
-            stop_time=0.0,
+            real_time=0,
+            start_time=0,
+            stop_time=0,
         ),
     ]


### PR DESCRIPTION
Currently these parameters are floats, which makes the frameReceiver crash when trying to parse simulated data. This changes the parameters to be ints as they should be.

- [x] Depends on #110  

Fixes #94 