### PR TITLE
Fix eiger put responses to reflect real detector behaviour (Fixes #114)

### DIFF
--- a/src/tickit_devices/eiger/eiger.py
+++ b/src/tickit_devices/eiger/eiger.py
@@ -242,3 +242,73 @@ class EigerDevice(Device):
 
     def _is_in_state(self, state: State) -> bool:
         return self.get_state() is state
+
+
+def get_changed_parameters(key: str) -> list[str]:
+    """Get the list of parameters that may have changed as a result of putting
+    to the parameter provided.
+
+    Args:
+        key: string key of the changed parameter within the detector subsystem
+
+    Returns:
+        list[str]: a list of keys which may have been changed after a PUT request
+    """
+    match key:
+        case "auto_summation":
+            return ["auto_summation", "frame_count_time"]
+        case "count_time" | "frame_time":
+            return [
+                "bit_depth_image",
+                "bit_depth_readout",
+                "count_time",
+                "countrate_correction_count_cutoff",
+                "frame_count_time",
+                "frame_time",
+            ]
+        case "flatfield":
+            return ["flatfield", "threshold/1/flatfield"]
+        case "incident_energy" | "photon_energy":
+            return [
+                "element",
+                "flatfield",
+                "incident_energy",
+                "photon_energy",
+                "threshold/1/energy",
+                "threshold/1/flatfield",
+                "threshold/2/energy",
+                "threshold/2/flatfield",
+                "threshold_energy",
+                "wavelength",
+            ]
+        case "pixel_mask":
+            return ["pixel_mask", "threshold/1/pixel_mask"]
+        case "threshold/1/flatfield":
+            return ["flatfield", "threshold/1/flatfield"]
+        case "roi_mode":
+            return ["count_time", "frame_time", "roi_mode"]
+        case "threshold_energy" | "threshold/1/energy":
+            return [
+                "flatfield",
+                "threshold/1/energy",
+                "threshold/1/flatfield",
+                "threshold/2/flatfield",
+                "threshold_energy",
+            ]
+        case "threshold/2/energy":
+            return [
+                "flatfield",
+                "threshold/1/flatfield",
+                "threshold/2/energy",
+                "threshold/2/flatfield",
+            ]
+        case "threshold/1/mode":
+            return ["threshold/1/mode", "threshold/difference/mode"]
+        case "threshold/2/mode":
+            return ["threshold/2/mode", "threshold/difference/mode"]
+        case "threshold/1/pixel_mask":
+            return ["pixel_mask", "threshold/1/pixel_mask"]
+        case "threshold/difference/mode":
+            return ["difference_mode"]  # replicating API inconsistency
+        case _:
+            return [key]

--- a/src/tickit_devices/eiger/eiger_adapters.py
+++ b/src/tickit_devices/eiger/eiger_adapters.py
@@ -368,7 +368,7 @@ class EigerRESTAdapter(HttpAdapter):
             self.device.stream_config[param] = attr
 
             LOGGER.debug("Set " + str(param) + " to " + str(attr))
-            return web.json_response(serialize([param]))
+            return web.json_response([])
         else:
             LOGGER.debug("Eiger has no config variable: " + str(param))
             return web.json_response(status=404)
@@ -415,7 +415,7 @@ class EigerRESTAdapter(HttpAdapter):
             self.device.monitor_config[param] = attr
 
             LOGGER.debug("Set " + str(param) + " to " + str(attr))
-            return web.json_response(serialize([param]))
+            return web.json_response([])
         else:
             LOGGER.debug("Eiger has no config variable: " + str(param))
             return web.json_response(status=404)
@@ -482,7 +482,7 @@ class EigerRESTAdapter(HttpAdapter):
             self.device.filewriter_config[param] = attr
 
             LOGGER.debug("Set " + str(param) + " to " + str(attr))
-            return web.json_response(serialize([param]))
+            return web.json_response([])
         else:
             LOGGER.debug("Eiger has no config variable: " + str(param))
             return web.json_response(status=404)

--- a/src/tickit_devices/eiger/eiger_adapters.py
+++ b/src/tickit_devices/eiger/eiger_adapters.py
@@ -93,7 +93,7 @@ _changed_parameters = {  # if not given, changed parameter list for key is [key]
         "threshold/2/flatfield",
         "threshold_energy",
     ],
-    "threshold/difference/mode": ["difference_mode"]  # replicating API inconsistency
+    "threshold/difference/mode": ["difference_mode"],  # replicating API inconsistency
 }
 
 
@@ -208,6 +208,7 @@ class EigerRESTAdapter(HttpAdapter):
             full_param = f"threshold/{threshold}/{param}"
             if full_param in _changed_parameters:
                 param_list = _changed_parameters[full_param]
+                print(full_param, param_list)
             else:
                 param_list = [full_param]
 

--- a/tests/eiger/test_eiger_adapters.py
+++ b/tests/eiger/test_eiger_adapters.py
@@ -1,7 +1,7 @@
 import pytest
 from pytest_mock import MockerFixture
 
-from tickit_devices.eiger.eiger import EigerDevice
+from tickit_devices.eiger.eiger import EigerDevice, get_changed_parameters
 from tickit_devices.eiger.eiger_adapters import EigerRESTAdapter, EigerZMQAdapter
 
 
@@ -72,3 +72,60 @@ async def test_rest_adapter_command_404(mocker: MockerFixture):
     assert (await eiger_adapter.trigger_eiger(request)).status == 404
     assert (await eiger_adapter.cancel_eiger(request)).status == 404
     assert (await eiger_adapter.abort_eiger(request)).status == 404
+
+
+@pytest.mark.asyncio
+async def test_detector_put_responses(mocker: MockerFixture):
+    # test special keys have non-trivial response
+    custom_response_keys = [
+        "auto_summation",
+        "count_time",
+        "frame_time",
+        "flatfield",
+        "incident_energy",
+        "photon_energy",
+        "pixel_mask",
+        "threshold/1/flatfield",
+        "roi_mode",
+        "threshold_energy",
+        "threshold/1/energy",
+        "threshold/2/energy",
+        "threshold/1/mode",
+        "threshold/2/mode",
+        "threshold/1/pixel_mask",
+        "threshold/difference/mode",
+    ]
+
+    for key in custom_response_keys:
+        assert get_changed_parameters(key) != [key]
+
+    assert get_changed_parameters("phi_start") == ["phi_start"]
+    assert get_changed_parameters("threshold/1/pixel_mask") == [
+        "pixel_mask",
+        "threshold/1/pixel_mask",
+    ]
+    assert get_changed_parameters("threshold/difference/mode") == ["difference_mode"]
+
+    eiger_adapter = EigerRESTAdapter(EigerDevice())
+
+    request = mocker.MagicMock()
+    request.json = mocker.AsyncMock()
+
+    request.match_info = {"parameter_name": "count_time", "value": 1.0}
+    response = await eiger_adapter.put_config(request)
+    assert response.body == (
+        b'["bit_depth_image", "bit_depth_readout", "count_time",'
+        b' "countrate_correction_count_cutoff",'
+        b' "frame_count_time", "frame_time"]'
+    )
+    # trivial case just returns the single parameter
+    request.match_info = {"parameter_name": "phi_start", "value": 1.0}
+    response = await eiger_adapter.put_config(request)
+    assert response.body == b'["phi_start"]'
+
+    # test threshold responses work
+
+    request.match_info = {"parameter_name": "mode", "threshold": "1", "value": 1}
+    request.json = mocker.AsyncMock(return_value={"value": 1})
+    response = await eiger_adapter.put_threshold_config(request)
+    assert response.body == b'["threshold/1/mode", "threshold/difference/mode"]'

--- a/tests/eiger/test_eiger_system.py
+++ b/tests/eiger/test_eiger_system.py
@@ -87,7 +87,7 @@ async def test_eiger_system(tickit_task):
             json={"value": "enabled"},
             timeout=REQUEST_TIMEOUT,
         ) as response:
-            assert ["mode"] == (await response.json())
+            assert [] == (await response.json())
 
         # Test filewriter, monitor and stream endpoints
         async with session.get(
@@ -108,7 +108,7 @@ async def test_eiger_system(tickit_task):
             json={"value": "enabled"},
             timeout=REQUEST_TIMEOUT,
         ) as response:
-            assert ["mode"] == (await response.json())
+            assert [] == (await response.json())
 
         async with session.get(
             MONITOR_URL + "status/error",
@@ -128,7 +128,7 @@ async def test_eiger_system(tickit_task):
             json={"value": "enabled"},
             timeout=REQUEST_TIMEOUT,
         ) as response:
-            assert ["mode"] == (await response.json())
+            assert [] == (await response.json())
 
         async with session.put(
             DETECTOR_URL + "config/threshold/1/energy",
@@ -136,7 +136,13 @@ async def test_eiger_system(tickit_task):
             json={"value": 6829},
             timeout=REQUEST_TIMEOUT,
         ) as response:
-            assert ["energy"] == (await response.json())
+            assert [
+                "flatfield",
+                "threshold/1/energy",
+                "threshold/1/flatfield",
+                "threshold/2/flatfield",
+                "threshold_energy",
+            ] == (await response.json())
 
         async with session.get(
             DETECTOR_URL + "config/threshold/1/energy",
@@ -151,7 +157,7 @@ async def test_eiger_system(tickit_task):
             json={"value": "enabled"},
             timeout=REQUEST_TIMEOUT,
         ) as response:
-            assert ["mode"] == (await response.json())
+            assert ["difference_mode"] == (await response.json())
 
         async with session.get(
             DETECTOR_URL + "config/threshold/difference/mode",


### PR DESCRIPTION
https://github.com/DiamondLightSource/tickit-devices/issues/114

Changing return value of PUTs to various rw fields, following testing against a real Eiger 2 1M.
The list of changed parameters could be added as field metadata but it would have to be removed when sent to clients after a GET request.